### PR TITLE
Refactored GiffyGram.css so post entry form only shows once post butt…

### DIFF
--- a/src/scripts/GiffyGram.js
+++ b/src/scripts/GiffyGram.js
@@ -10,9 +10,7 @@ export const GiffyGram = () => {
            ${navBar()}
         </div>
         <div class="post__entry__form">
-            <div><button class="miniMode" id="miniMode">POST GIF HERE</button>
-            ${PostEntry()}
-            </div>
+            <button class="miniMode" id="miniMode">Click here to post a gif!</button>
         </div>
         <section class="post">
             ${PostList()}
@@ -23,3 +21,10 @@ export const GiffyGram = () => {
     </div>
     `;
 };
+
+document.addEventListener("click", event => {
+    if (event.target.id === "miniMode") {
+        const entryFormContainer = document.querySelector(".post__entry__form")
+        entryFormContainer.innerHTML = PostEntry()
+    }
+})

--- a/src/styles/post.css
+++ b/src/styles/post.css
@@ -1,5 +1,6 @@
 .miniMode {
     padding: 1rem;
+    width: 50%;
     margin: 0 25%;
     border: 1px dashed slategrey;
     border-radius: 0.5rem;


### PR DESCRIPTION
…on is clicked

#### Changes Made
1. Modified file `GiffyGram.css` to only display post entry form when the post gif button is clicked.
​
#### Steps to Review
1. Checkout this branch locally.
    ```
    git fetch --all
    git checkout jb-postEntryForm
    ```
2. Open a new Terminal tab (⌘T) and navigate to the server directory.
3. Test app functionality.
    > Once logged in on the main page, click 'Click here to post a gif!' button. Once the form is submitted or canceled, the form will disappear again.
4. View code file.
    > Confirm file modifications are present as indicated above.
    > Confirm no unused code or extraneous comments exist.
